### PR TITLE
disable AE wireless terminals from invtweaks sorts

### DIFF
--- a/config/invtweaks-client.toml
+++ b/config/invtweaks-client.toml
@@ -101,6 +101,18 @@
 		containerClass = "appeng.container.implementations.WirelessTermContainer"
 		sortRange = ""
 
+	[[sorting.containerOverrides]]
+		containerClass = "tfar.ae2wt.wirelesscraftingterminal.WirelessCraftingTerminalContainer"
+		sortRange = ""
+
+	[[sorting.containerOverrides]]
+		containerClass = "tfar.ae2wt.wirelessfluidterminal.WirelessFluidTerminalContainer"
+		sortRange = ""
+
+	[[sorting.containerOverrides]]
+		containerClass = "tfar.ae2wt.wirelessinterfaceterminal.WirelessInterfaceTerminalContainer"
+		sortRange = ""
+
 #Tweaks
 [tweaks]
 	#Enable auto-refill


### PR DESCRIPTION
Disable AE2 Wireless Terminals containers from being sorted by inventorytweaks.

When pressing the sort button on a AE2 Wireless (crafting) Terminal, Inventory Tweaks will move your armor and any modules around.

That is specially a problem when using an infinity booster upgrade on the terminal, because invtweaks removes the booster from the upgrade slot, making the terminal unusable until it's back in range.

---
References for the classnames:
[CraftingTerminal](https://github.com/Tfarcenim/AE2WirelessTerminalLibrary/blob/1.16.5-forge/src/main/java/tfar/ae2wt/wirelesscraftingterminal/WirelessCraftingTerminalContainer.java#L61)
[FluidTerminal](https://github.com/Tfarcenim/AE2WirelessTerminalLibrary/blob/1.16.5-forge/src/main/java/tfar/ae2wt/wirelessfluidterminal/WirelessFluidTerminalContainer.java#L34)
[InterfaceTerminal](https://github.com/Tfarcenim/AE2WirelessTerminalLibrary/blob/1.16.5-forge/src/main/java/tfar/ae2wt/wirelessinterfaceterminal/WirelessInterfaceTerminalContainer.java#L51)
