### PR TITLE
#91 Added botany pot recipes for tier 6 seeds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -315,6 +315,17 @@ connectivity-2.4-1.16.5
 
 ### Changed
 - Remove unused avaritia stuff out of JEI
+- Added botany pot recipes for tier 6 seeds
+    - End Steel Alloy
+    - Energetic Alloy
+    - Dark Steel Alloy
+    - Charged Certus Quartz
+    - Crystalline Pink Slime
+    - Neutronium
+    - Pink Slime Ingot
+    - Melodic Alloy
+    - vibrant Alloy
+    - stellar Alloy
 
 ### Fixed
 - 

--- a/kubejs/server_scripts/NTC/base/modrecipes/botany_pots/botany_pots.js
+++ b/kubejs/server_scripts/NTC/base/modrecipes/botany_pots/botany_pots.js
@@ -227,7 +227,17 @@ onEvent(`recipes`, e => {
   //Tier 6 Crops
   tier([
     `dragon_egg`,
-    `nether_star`
+    `nether_star`,
+    `end_steel_alloy`,
+    `energetic_alloy`,
+    `dark_steel_alloy`,
+    `charged_certus_quartz`,
+    `crystalline_pink_slime`,
+    `neutronium`,
+    `pink_slime_ingot`,
+    `melodic_alloy`,
+    `vibrant_alloy`,
+    `stellar_alloy`
   ], 4750, `insanium`)
   /*
   //Magical Crops


### PR DESCRIPTION
- Added botany pot recipes for tier 6 seeds
    - End Steel Alloy
    - Energetic Alloy
    - Dark Steel Alloy
    - Charged Certus Quartz
    - Crystalline Pink Slime
    - Neutronium
    - Pink Slime Ingot
    - Melodic Alloy
    - vibrant Alloy
    - stellar Alloy